### PR TITLE
Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,40 @@
+branches:
+  only:
+    - main
+
+language: rust
+rust:
+  - stable
+
+env:
+  global:
+    - SCCACHE_VERSION=0.2.13
+    - SCCACHE=$HOME/.sccache/bin/sccache
+    - RUSTC_WRAPPER=$SCCACHE
+
+cache:
+  directories:
+    - $HOME/.cache/sccache
+    - $HOME/.cargo
+    - $HOME/.rustup
+
+before_install:
+  - rustup component add clippy rustfmt
+  - cargo clippy --version
+  - cargo fmt --version
+  - |
+    mkdir -p $HOME/.sccache/bin
+    pushd $HOME/.sccache
+    curl -LO https://github.com/mozilla/sccache/releases/download/$SCCACHE_VERSION/sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl.tar.gz
+    tar -C bin -xvf sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl.tar.gz --wildcards '*/sccache' --strip 1
+    popd
+  - $SCCACHE --version
+
+script:
+  - cargo fmt -- --check
+  - cargo clippy --workspace --all-features --all-targets -- -D warnings
+  - cargo build --locked --workspace --all-features --verbose
+  - cargo test --workspace --all-features --verbose
+
+before_cache:
+  - rm -rf "$TRAVIS_HOME/.cargo/registry/src"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
     - SCCACHE_VERSION=0.2.13
     - SCCACHE=$HOME/.sccache/bin/sccache
     - RUSTC_WRAPPER=$SCCACHE
+    - CARGO_INCREMENTAL=0
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
 
 script:
   - cargo fmt -- --check
-  - cargo clippy --workspace --all-features --all-targets -- -D warnings
+  - cargo clippy --locked --workspace --all-features --all-targets -- -D warnings
   - cargo build --locked --workspace --all-features --verbose
   - cargo test --workspace --all-features --verbose
 


### PR DESCRIPTION
Default travis config for rust, mainly taken from [ethcontracts](https://github.com/gnosis/ethcontract-rs/blob/346d71e9684fc25e7a60d28e06107bb7b1f9812b/.travis.yml#L89) for the caching logic and adding `--locked` for `cargo build` to make sure we operate on an up to date lockfile.